### PR TITLE
feat: Added wallet-register contract and repl files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,32 @@
+# top-most EditorConfig file
+root = true
+
+# Set the default charset
+[*]
+charset = utf-8
+indent_size = 2
+
+# Indentation settings
+[*.js]
+indent_style = space
+indent_size = 2
+
+[*.html]
+indent_style = space
+indent_size = 4
+
+[*.css]
+indent_style = space
+indent_size = 2
+
+# End of line settings
+[*.{js,html,css}]
+end_of_line = lf
+
+# Trim trailing whitespace
+[*.{js,html,css}]
+trim_trailing_whitespace = true
+
+# Insert final newline
+[*.{js,html,css}]
+insert_final_newline = true

--- a/pact/wallet-register.pact
+++ b/pact/wallet-register.pact
@@ -1,0 +1,54 @@
+(namespace (read-string 'webauthn-namespace))
+
+(module wallet-register GOVERNANCE
+  (defconst GOVERNANCE_KEYSET (read-string 'webauthn-keyset-name))
+
+  (defcap GOVERNANCE() 
+    (enforce-guard GOVERNANCE_KEYSET)
+  )
+
+	(defschema wallet-schema
+		name : string
+	)
+	(deftable wallet-table:{wallet-schema})
+
+	(defun register-wallet (domain:string name:string)
+		@model [
+			(property (!= domain ""))
+			(property (!= name ""))
+			(property (not (row-exists wallet-table domain 'before)))
+			(property (row-exists wallet-table domain 'after))
+			(property (authorized-by GOVERNANCE_KEYSET))
+		]
+		(enforce (!= domain "") "domain cannot be an empty string")
+		(enforce (!= name "") "name cannot be an empty string")
+		
+		(with-capability (GOVERNANCE)
+			(insert wallet-table domain 
+				{ 'name : name }
+			)
+		)
+	)
+
+	(defun get-wallets()
+		(map (get-wallet) (keys wallet-table))
+	)
+
+	(defun get-wallet(id:string)
+		(with-read wallet-table id
+			{ 'name   := name }
+			{ 'domain : id
+      , 'name   : name
+			}
+		)
+	)
+    
+)
+
+(if (read-msg 'upgrade)
+	["Upgrade successful"]
+	(let ((ks wallet-register.GOVERNANCE_KEYSET))
+		(enforce-guard ks)
+		(create-table wallet-table)
+	)
+)

--- a/pact/wallet-register.repl
+++ b/pact/wallet-register.repl
@@ -1,0 +1,79 @@
+(load "util/guards.repl")
+
+(env-data
+  { 'webauthn-keyset :
+    { 'pred          : "keys-all"
+    , 'keys          :
+      [ "368820f80c324bbc7c2b0610688a7da43e39f91d118732671cd9c7500ff43cca" ]
+    }
+  }
+)
+(env-sigs
+  [{ 'key  : "368820f80c324bbc7c2b0610688a7da43e39f91d118732671cd9c7500ff43cca"
+   , 'caps : []
+   }
+  ]
+)
+
+(begin-tx "Create webauthn namespace and define webauthn keyset")
+(let* ((webauthn-namespace (ns.create-principal-namespace (read-keyset 'webauthn-keyset)))
+       (webauthn-keyset (format "{}.{}" [ webauthn-namespace 'webauthn-keyset ]))
+      )
+  (define-namespace
+    webauthn-namespace
+    (read-keyset 'webauthn-keyset)
+    (read-keyset 'webauthn-keyset))
+  (namespace webauthn-namespace)
+  (define-keyset
+    webauthn-keyset
+    (read-keyset 'webauthn-keyset)
+  )
+)
+(commit-tx)
+
+(env-data {})
+(env-sigs [])
+
+(env-data
+  { 'webauthn-keyset-name : "n_560eefcee4a090a24f12d7cf68cd48f11d8d2bd9.webauthn-keyset"
+  , 'webauthn-namespace   : "n_560eefcee4a090a24f12d7cf68cd48f11d8d2bd9"
+  , 'upgrade              : false
+  }
+)
+(env-sigs
+  [{ 'key  : "368820f80c324bbc7c2b0610688a7da43e39f91d118732671cd9c7500ff43cca"
+   , 'caps : []
+   }
+  ]
+)
+(begin-tx "Load webauthn contract")
+(load "wallet-register.pact")
+(commit-tx)
+
+(env-data {})
+(env-sigs [])
+
+(verify "n_560eefcee4a090a24f12d7cf68cd48f11d8d2bd9.wallet-register")
+
+;;;;;;;;;;;;;;;;;;;;;;;;;
+; Prepare test accounts ;
+;;;;;;;;;;;;;;;;;;;;;;;;;
+(env-sigs
+  [{ 'key  : "368820f80c324bbc7c2b0610688a7da43e39f91d118732671cd9c7500ff43cca"
+   , 'caps : []
+   }
+  ]
+)
+
+(begin-tx)
+(n_560eefcee4a090a24f12d7cf68cd48f11d8d2bd9.wallet-register.register-wallet
+  "www.wallet.com"
+  "Wallet"
+)
+(expect "Wallet has been registered" 
+  [{ 'domain: "www.wallet.com"
+  , 'name: "Wallet"
+  }]
+  (n_560eefcee4a090a24f12d7cf68cd48f11d8d2bd9.wallet-register.get-wallets)
+)
+(commit-tx)


### PR DESCRIPTION
Added the wallet-register.pact and wallet-register.repl files and a generic .editorconfig

This contract creates a wallet-register table that is guarded by the same keyset as the other webauthn contracts.