### PR TITLE
Fix the network id stored in local storage during registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "generate": "npx pactjs contract-generate --file=\"./pact/webauthn.pact\" --namespace=n_560eefcee4a090a24f12d7cf68cd48f11d8d2bd9",
     "postinstall": "npx pactjs contract-generate --file=\"./pact/root/fungible-v2.pact\" --file=\"./pact/root/gas-payer-v1.pact\" --file=\"./pact/root/fungible-xchain-v1.pact\" --file=\"./pact/root/coin.pact\" --file=\"./pact/webauthn-guard.pact\" --file=\"./pact/webauthn-wallet.pact\" --file=\"./pact/l2-coin.pact\" --namespace=n_560eefcee4a090a24f12d7cf68cd48f11d8d2bd9",
     "lint": "next lint",
-    "start": "next start",
+    "start": "next start --port 1337",
     "update": "tsx pact/deploy/update-contracts.mts"
   },
   "dependencies": {

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -73,7 +73,11 @@ export default function Account() {
       domain: host,
     });
 
-    storeAccount({ accountName: caccount, alias: data.alias, network: host });
+    storeAccount({
+      accountName: caccount,
+      alias: data.alias,
+      network: data.networkId,
+    });
   };
 
   return (


### PR DESCRIPTION
  - it was storing the domain rather than the network id, causing the url to become malformed