### PR TITLE
fix(card): fix card center layout that broke because of copy button padding

### DIFF
--- a/src/components/Card/AccountNetwork.tsx
+++ b/src/components/Card/AccountNetwork.tsx
@@ -6,7 +6,7 @@ import { useCopyToClipboard } from 'usehooks-ts';
 import { AccountRevealer } from '../AccountRevealer/AccountRevealer';
 
 import * as styles from './AccountNetwork.css';
-import { cardContentCenter, network } from './Card.css';
+import { network } from './Card.css';
 
 type AccountNetworkProps = {
   account: Account;
@@ -33,7 +33,7 @@ export default function AccountNetwork({
   const [accountNamespace, accountName] = account.accountName.split(':');
 
   return (
-    <Stack flexDirection="column" className={cardContentCenter}>
+    <Stack flexDirection="column">
       <Stack flexDirection="row" alignItems="center" className={styles.account}>
         {accountName && (
           <span className={styles.namespace}>{accountNamespace}:</span>

--- a/src/components/Card/Card.css.ts
+++ b/src/components/Card/Card.css.ts
@@ -122,10 +122,6 @@ export const device = style({
   width: '1.5rem',
 });
 
-export const cardContentCenter = style({
-  marginBlockStart: 'clamp(0px, 4vw, 1.5rem)',
-});
-
 export const network = style([
   atoms({
     fontWeight: 'bodyFont.regular',


### PR DESCRIPTION
<img width="549" alt="Screenshot 2024-02-21 at 07 58 29" src="https://github.com/kadena-community/webauthn-wallet/assets/2759225/b54c130a-43aa-4c9e-b0dc-d0f44dcc4441">
<img width="624" alt="Screenshot 2024-02-21 at 08 05 31" src="https://github.com/kadena-community/webauthn-wallet/assets/2759225/5758236b-258d-4c6e-84b9-0705653919b3">
