### PR TITLE
Draft changes for construct and send a tx from an app

### DIFF
--- a/docs/KIP-0030/guides/send-transaction.md
+++ b/docs/KIP-0030/guides/send-transaction.md
@@ -1,16 +1,16 @@
 ---
-title: Send unsigned transactions to Kadena SpireKey
+title: Create transactions for Kadena SpireKey
 description:
   If you're an application developer, you can enable users to sign transactions
-  using their Kadena SpireKey accounts by constructing the transaction in the
+  using their Kadena SpireKey account by constructing the transaction in the
   proper format and sending the unsigned transaction to the SpireKey endpoint.
-menu: Authentication and authorization
-label: Send unsigned transactions to Kadena SpireKey
+menu: Authenticate and authorize
+label: Construct transactions
 order: 2
 layout: full
 ---
 
-# Send unsigned transactions to Kadena SpireKey
+# Create transactions for Kadena SpireKey
 
 If you enable your application to connect to a Kadena SpireKey wallet as
 described in [Integrate with Kadena SpireKey](/build/authentication/integrate),
@@ -45,10 +45,11 @@ permissions.
 
 When users register an account using Kadena SpireKey, the cryptographic
 algorithm used to generate the public and secret keys is different from the
-cryptographic algorithm used to generate the public and secret keys for previous
-Kadena accounts. To differentiate Kadena SpireKey account public keys from other
-public keys, transactions must include both the public key and the `scheme`
-attribute set to `WebAuthn` as its value.
+cryptographic algorithm and ED25519 signature scheme used to generate the public
+and secret keys for other Kadena accounts. To differentiate Kadena SpireKey
+account public keys from other public keys, transactions must include both the
+public key and the `scheme` attribute set to `WebAuthn` as its value when
+signing transactions.
 
 ```ts
 { pubKey: webAuthnPublicKey, scheme: 'WebAuthn' }
@@ -160,12 +161,12 @@ navigate to the `sign` endpoint. For example, https://spirekey.kadena.io/sign.
 In the following table, you can see the parameters that are currently accepted
 by Kadena SpireKey.
 
-| Parameter      | Type    | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| -------------- | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `transaction`  | string  | Required | A base64 encoded string of the unsigned transaction.                                                                                                                                                                                                                                                                                                                                                                                                 |
-| `returnUrl`    | string  | Required | The url, encoded as a uriComponent, that the wallet should redirect users to after they have signed the transaction.                                                                                                                                                                                                                                                                                                                                 |
-| `translations` | string  | Optional | Custom descriptions that explain what capabilities or operations that the user is user signing for. For more information about using translations to describe transaction details, see [Translate transaction operations](/build/authentication/translate).                                                                                                                                                                                          |
-| `optimistic`   | boolean | Optional | Allows applications to continue the transaction flows without having to wait for the transaction to be confirmed on the blockchain. When this parameter is included, `pendingTxIds` are returned so that the application can keep track of the status of the submitted transactions and update the UI accordingly. For more information about the optimistic transaction flow, see [Optimistic workflow](/build/authentication/optimistic-workflow). |
+| Parameter      | Type    | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| -------------- | ------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `transaction`  | string  | Required | A base64 encoded string of the unsigned transaction.                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `returnUrl`    | string  | Required | The url, encoded as a uriComponent, that the wallet should redirect users to after they have signed the transaction.                                                                                                                                                                                                                                                                                                                                                                                      |
+| `translations` | string  | Optional | Custom descriptions that explain what capabilities or operations that the user is user signing for. For more information about using translations to describe transaction details, see [Translate signing operations](/build/authentication/translate).                                                                                                                                                                                                                                                   |
+| `optimistic`   | boolean | Optional | Allows applications to continue the transaction flows without having to wait for the transaction to be confirmed on the blockchain. When this parameter is included, `pendingTxIds` are returned so that the application can keep track of the status of the submitted transactions and update the UI accordingly. For more information about the optimistic transaction flow, see [Allow optimistic account onboarding](/build/authentication/integrate#allow-optimistic-account-onboardingh-380147766). |
 
 The following is an example of how you would construct the route:
 
@@ -191,10 +192,10 @@ transaction and optional parameters are included as URL parameters. If the
 transaction was not successfully signed, the unsigned transaction is returned in
 the URL parameters.
 
-| Parameter      | Type     | Required | Description                                                                                                                                       |
-| -------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `transaction`  | string   | Required | A base64 encoded string of the signed or unsigned transaction.                                                                                    |
-| `pendingTxIds` | string[] | Optional | Pending transaction identifiers that enable the application to move forward withut waiting for the transaction to be confirmed on the blockchain. |
+| Parameter      | Type     | Required | Description                                                                                                                                        |
+| -------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `transaction`  | string   | Required | A base64 encoded string of the signed or unsigned transaction.                                                                                     |
+| `pendingTxIds` | string[] | Optional | Pending transaction identifiers that enable the application to move forward without waiting for the transaction to be confirmed on the blockchain. |
 
 To verify that a transaction has been successfully signed, you can check the
 `sigs` field in the transaction. If the field has undefined signatures, you


### PR DESCRIPTION
@eileenmguo @EnoF 
I took a stab at updating this guide in preparation for moving the info into the official documentation, but I have some questions about the content that I think would be good to flesh out.

1) What would the YAML look like for a webauthn* transaction?
2) To construct the transaction, do they use this `n_eef68e581f767dd66c4d4c39ed922be944ede505` namespace? I'm guessing yes, for this contract on this network(?) but if not, how do they get this context for the `webauthn-wallet.transfer` function 
3) How do they get this "from account" identifier `c:bF51UeSqhrSjEET1yUWBYabDTfujlAZke4R70I4rrHc`? (Does the app store it in a variable or is it passed back from the SpireKey wallet?)
4) Is there an example of how they could get the public key for the account` "pubKey": "WEBAUTHN-a50102032620012158200df3845d4ad0f626a3c860715ad3d4bd7bbee03330aa32878d6baa045e98f64f2258206a93722f35f3d0692dc4c26703653498eae51816ffb7b70e4670b010103bd9eb",`
5) Can I get an example of how to poll for the transaction status using the chainweb-data API and the result? 

Sorry if these are stupid questions. I'm just not sure if someone could construct a transaction from the example without a little more help/direction.

*Using the YAML for `coin.transfer` as an example, I was thinking of including something along the lines of this:

```
code: |-
  (webauthn-wallet.transfer 
    "c:kadena-spirekey-account" 
    "k:5ec41b89d323398a609ffd54581f2bd6afc706858063e8f3e8bc76dc5c35e2c0" 
    1.0)
publicMeta:
  chainId: "1"
  sender: "k:bbccc99ec9eeed17d60159fbb88b09e30ec5e63226c34544e64e750ba424d35e"
  gasLimit: 600
  gasPrice: 0.0000001
  ttl: 600
  creationTime: 1713899239
networkId: "testnet04"
keyPairs:
  - public: c128ac214c2e14e432e862d0ebd43ac1fd582a44d85528b63e346fc5c6583849
    secret: 2ff92410b7847fb4dec848b7c72f5fe78f9e7a0ece8d72cb7a20b07c2ee96b72
    caps:
      - name: "webauthn-wallet.TRANSFER"
        args: ["k:bbccc99ec9eeed17d60159fbb88b09e30ec5e63226c34544e64e750ba424d35e",
    "k:5ec41b89d323398a609ffd54581f2bd6afc706858063e8f3e8bc76dc5c35e2c0",
    1.0]
      - name: "webauthn-wallet.GAS_PAYER"
        args: []
type: exec
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207171885464822