### PR TITLE
Set form-id to the correct value

### DIFF
--- a/src/components/Recover/NetworkIdForm.tsx
+++ b/src/components/Recover/NetworkIdForm.tsx
@@ -58,10 +58,7 @@ export const NetworkIdForm: FC<StepProps> = ({
       animate={isVisible ? 'visible' : 'hidden'}
       variants={animationVariants}
     >
-      <form
-        id={`registration-form-${stepIndex}`}
-        onSubmit={handleSubmit(onSubmit)}
-      >
+      <form id={`recover-form-${stepIndex}`} onSubmit={handleSubmit(onSubmit)}>
         <SurfaceCard
           title="Network"
           description={


### PR DESCRIPTION
When selecting the networkId was enabled for recovery, the form didn't submit because the id wasn't correct.