### PR TITLE
"fix" for z-index of the cards, preventing the cards to overlap the a…

### DIFF
--- a/spirekey/src/components/CardCollection/CardCollection.tsx
+++ b/spirekey/src/components/CardCollection/CardCollection.tsx
@@ -92,7 +92,7 @@ export default function CardCollection({
                 }}
                 className={card({ variant: getCardVariant(i) })}
                 style={{
-                  zIndex: `${i}`,
+                  zIndex: `${activeCard === i ? accounts.length : i}`,
                   marginBlockEnd: `${
                     hasActiveCard ? marginBlockEnd : cardOverlap
                   }px`,


### PR DESCRIPTION
…ccount buttons

With this change the cards will always be displayed "below" the account buttons. Another solution needs to be found to let the user select another card for this kind of viewports.

<img width="1101" alt="image" src="https://github.com/kadena-community/webauthn-wallet/assets/9663397/8f31d41e-6222-40db-8106-60c462399a3d">
