### PR TITLE
Fix chainId to be used when provided

### DIFF
--- a/spirekey/src/app/(wallet)/connect/page.tsx
+++ b/spirekey/src/app/(wallet)/connect/page.tsx
@@ -41,6 +41,7 @@ export default function Connect({ searchParams }: ConnectProps) {
         returnUrl={decodeURIComponent(returnUrl)}
         reason={decodeURIComponent(reason)}
         networkId={networkId}
+        chainId={chainId}
       />
       <CardCollection
         returnUrl={decodeURIComponent(returnUrl)}

--- a/spirekey/src/app/(wallet)/register/page.tsx
+++ b/spirekey/src/app/(wallet)/register/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Stack } from '@kadena/react-ui';
+import type { ChainId } from '@kadena/client';
 import dynamic from 'next/dynamic';
 
 const Registration = dynamic(
@@ -14,16 +15,18 @@ type Props = {
   searchParams: {
     redirectUrl?: string;
     networkId?: string;
+    chainId?: ChainId;
   };
 };
 
 export default function Register({ searchParams }: Props) {
   const redirectUrl = searchParams.redirectUrl;
   const networkId = searchParams.networkId;
+  const chainId = searchParams.chainId;
 
   return (
     <Stack flexDirection="column" gap="md">
-      <Registration redirectUrl={redirectUrl} networkId={networkId} />
+      <Registration redirectUrl={redirectUrl} networkId={networkId} chainId={chainId} />
     </Stack>
   );
 }

--- a/spirekey/src/components/Registration/Registration.tsx
+++ b/spirekey/src/components/Registration/Registration.tsx
@@ -13,6 +13,7 @@ import { getDevnetNetworkId } from '@/utils/shared/getDevnetNetworkId';
 import { getNewWebauthnKey } from '@/utils/webauthnKey';
 import { Box, Stack, Text } from '@kadena/react-ui';
 import { atoms } from '@kadena/react-ui/styles';
+import { ChainId } from '@kadena/types';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
@@ -24,9 +25,14 @@ import { Surface } from '../Surface/Surface';
 interface Props {
   redirectUrl?: string;
   networkId?: string;
+  chainId?: ChainId;
 }
 
-export default function Registration({ redirectUrl, networkId }: Props) {
+export default function Registration({
+  redirectUrl,
+  networkId,
+  chainId,
+}: Props) {
   const router = useRouter();
   const { registerAccount, accounts } = useAccounts();
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
@@ -39,9 +45,9 @@ export default function Registration({ redirectUrl, networkId }: Props) {
 
   const skipNetworkId = process.env.WALLET_NETWORK_ID && !devMode;
   const defaultFormData = {
-    networkId: skipNetworkId
-      ? process.env.WALLET_NETWORK_ID!
-      : networkId || getDevnetNetworkId(),
+    networkId:
+      networkId ||
+      (skipNetworkId ? process.env.WALLET_NETWORK_ID! : getDevnetNetworkId()),
     accountName: '',
   };
 
@@ -99,6 +105,7 @@ export default function Registration({ redirectUrl, networkId }: Props) {
       credentialId,
       domain: host,
       networkId: currentNetwork,
+      chainId,
     });
 
     completeRedirect();
@@ -138,7 +145,7 @@ export default function Registration({ redirectUrl, networkId }: Props) {
             networkId: currentNetwork,
             minApprovals: 1,
             minRegistrationApprovals: 1,
-            chainIds: [process.env.CHAIN_ID],
+            chainIds: [chainId || process.env.CHAIN_ID],
             devices: [
               {
                 'credential-id': '',

--- a/spirekey/src/components/shared/Connect/ConnectHeader.tsx
+++ b/spirekey/src/components/shared/Connect/ConnectHeader.tsx
@@ -4,14 +4,16 @@ import { useAccounts } from '@/context/AccountsContext';
 import { MonoSupervisorAccount } from '@kadena/react-icons';
 import { Box, ContentHeader, Stack } from '@kadena/react-ui';
 import './ConnectHeader.css';
+import { ChainId } from '@kadena/types';
 
 type Props = {
   returnUrl: string;
   reason: string;
   networkId?: string;
+  chainId?: ChainId;
 };
 
-export default function ConnectHeader({ returnUrl, reason, networkId }: Props) {
+export default function ConnectHeader({ returnUrl, reason, networkId, chainId }: Props) {
   const { accounts } = useAccounts();
 
   const filteredAccounts = accounts.filter(
@@ -48,7 +50,7 @@ export default function ConnectHeader({ returnUrl, reason, networkId }: Props) {
             </ButtonLink>
             <ButtonLink
               variant="primary"
-              href={`/register?redirectUrl=${Buffer.from(window.location.href).toString('base64')}&networkId=${networkId}`}
+              href={`/register?redirectUrl=${Buffer.from(window.location.href).toString('base64')}&networkId=${networkId}&chainId=${chainId}`}
             >
               Create
             </ButtonLink>

--- a/spirekey/src/context/AccountsContext.tsx
+++ b/spirekey/src/context/AccountsContext.tsx
@@ -105,11 +105,15 @@ const AccountsProvider = ({ children }: Props) => {
       for (const account of accounts) {
         for (const device of account.devices) {
           if (device.pendingRegistrationTx) {
-            pollForRegistrationTx({
-              requestKey: device.pendingRegistrationTx,
-              chainId: process.env.CHAIN_ID,
-              networkId: account.networkId,
-            });
+            await Promise.race(
+              account.chainIds.map((chainId) =>
+                pollForRegistrationTx({
+                  requestKey: device.pendingRegistrationTx!,
+                  chainId,
+                  networkId: account.networkId,
+                }),
+              ),
+            );
           }
         }
       }
@@ -191,6 +195,7 @@ const AccountsProvider = ({ children }: Props) => {
     credentialId,
     credentialPubkey,
     networkId,
+    chainId: cid,
   }: AccountRegistration): Promise<ITransactionDescriptor> => {
     const { requestKey, chainId } = await registerAccountOnChain({
       accountName,
@@ -200,6 +205,7 @@ const AccountsProvider = ({ children }: Props) => {
       credentialId,
       credentialPubkey,
       networkId,
+      chainId: cid,
     });
 
     const devices: Device[] = [


### PR DESCRIPTION
 - now SpireKey will attempt any chainId stored to check for the pendingTx. This is fine for now as we only create it per chain, but we should remodel the chainId to be part of the pendingRegistrationTx information